### PR TITLE
DendroRegister definition, Adjusting Rotations, and Clangformat file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,168 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/FEM/include/matvec.h
+++ b/FEM/include/matvec.h
@@ -201,7 +201,7 @@ inline void fem::seq::matvec(const T *pt_coords,const da* in,unsigned int pBegin
     const unsigned int ny=order+1;
     const unsigned int nz=order+1;
 
-    register unsigned int ijk[3];
+    DendroRegister unsigned int ijk[3];
     unsigned int cnum;
     const unsigned int pMin[]={pOctant.minX(),pOctant.minY(),pOctant.minZ()};
     const unsigned int pMax[]={pOctant.maxX(),pOctant.maxY(),pOctant.maxZ()};
@@ -221,7 +221,7 @@ inline void fem::seq::matvec(const T *pt_coords,const da* in,unsigned int pBegin
     ot::TreeNode childElem[NUM_CHILDREN];
 
 
-    register unsigned int pt_status;
+    DendroRegister unsigned int pt_status;
     childElem[0]=ot::TreeNode(pOctant.minX(),pOctant.minY(),pOctant.minZ(),pOctant.getLevel()+1,m_uiDim,maxDepth);
     childElem[1]=ot::TreeNode(pOctant.minX()+szb2,pOctant.minY(),pOctant.minZ(),pOctant.getLevel()+1,m_uiDim,maxDepth);
     childElem[2]=ot::TreeNode(pOctant.minX(),pOctant.minY()+szb2,pOctant.minZ(),pOctant.getLevel()+1,m_uiDim,maxDepth);

--- a/include/dendro.h
+++ b/include/dendro.h
@@ -1,24 +1,42 @@
 /**
  * @file dendro.h
- * @brief Basic dendro data types and definitions. 
+ * @brief Basic dendro data types and definitions.
  * @version 0.1
  * @date 2016-02-08
- * 
+ *
  * @copyright Copyright (c) 2022
- * 
+ *
  */
 #pragma once
-#include <climits>
-#include <complex>
-#include <stdio.h>
 #include <execinfo.h>
 #include <signal.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+
+#include <climits>
+#include <complex>
 #include <iostream>
 
+/**
+ * ==== C++ Standard-Based Definitions ====
+ *
+ * Any sort of definitions that need to be made based on used C++ standard
+ */
+#ifndef __cplusplus
+#error C++ is required
+#elif __cplusplus < 201703L
+// NOTE: The register keyword was depreciated in C++17, but it left for older
+// standards
+#define DendroRegister register
+#else
+#define DendroRegister
+#endif
 
-
+/**
+ * ==== Console Output Colors ====
+ *
+ */
 #define RED "\e[1;31m"
 #define BLU "\e[2;34m"
 #define GRN "\e[0;32m"
@@ -27,23 +45,22 @@
 #define CYN "\e[0;36m"
 #define NRM "\e[0m"
 
-
-
+/**
+ * ==== Data-type Definitions ====
+ *
+ */
 #ifdef USE_64BIT_INDICES
 #define DendroIntL long long
-#define DendroIntLSpecifier %lld
-#define DendroUIntLSpecifier %llu
+#define DendroIntLSpecifier % lld
+#define DendroUIntLSpecifier % llu
 #else
 #define DendroIntL unsigned int
-#define DendroIntLSpecifier %d
-#define DendroUIntLSpecifier %u
+#define DendroIntLSpecifier % d
+#define DendroUIntLSpecifier % u
 #endif
-
 
 #define DendroScalar double
 #define DendroComplex std::complex<double>
-
-
 
 //#define DendroIntL unsigned int
 typedef unsigned __int128 DendroUInt_128;
@@ -57,12 +74,12 @@ typedef unsigned __int128 DendroUInt_128;
 // mesh.h # defines.
 #define LOOK_UP_TABLE_DEFAULT UINT_MAX
 
-
 // TreeNode.h # defines.
 
 /**
- * Following are the flags that used to mark treeNodes when generating keys and mesh generation.
- * all these flags are stored in m_uiLevel since we know that, we need only 4 bits to store the level of the octree.
+ * Following are the flags that used to mark treeNodes when generating keys and
+ * mesh generation. all these flags are stored in m_uiLevel since we know that
+ * we need only 4 bits to store the level of the octree.
  *
  * bit -0 to bit -4 : level of the octant
  * bit -5 to 13 : are the Key flags.
@@ -73,17 +90,18 @@ typedef unsigned __int128 DendroUInt_128;
  * */
 #define OCT_FOUND 32
 #define OCT_KEY_NONE 64
-#define OCT_KEY_SPLITTER  128
-#define OCT_KEY_UP  256
-#define OCT_KEY_DOWN  512
-#define OCT_KEY_FRONT  1024
-#define OCT_KEY_BACK  2048
-#define OCT_KEY_LEFT  4096
-#define OCT_KEY_RIGHT  8192
+#define OCT_KEY_SPLITTER 128
+#define OCT_KEY_UP 256
+#define OCT_KEY_DOWN 512
+#define OCT_KEY_FRONT 1024
+#define OCT_KEY_BACK 2048
+#define OCT_KEY_LEFT 4096
+#define OCT_KEY_RIGHT 8192
 
 /**
  *
- * Note: Don't change that below numbering for key direction. With the following numbering you can always get the opposite direction performing XOR with 1.
+ * Note: Don't change that below numbering for key direction. With the following
+ * numbering you can always get the opposite direction performing XOR with 1.
  * Example OCT_DIR_LEFT= 1 XOR OCT_DIR_RIGHT
  *
  * */
@@ -100,7 +118,6 @@ typedef unsigned __int128 DendroUInt_128;
 #define OCT_DIR_LEFT_BACK 8
 #define OCT_DIR_LEFT_FRONT 9
 
-
 #define OCT_DIR_RIGHT_DOWN 10
 #define OCT_DIR_RIGHT_UP 11
 #define OCT_DIR_RIGHT_BACK 12
@@ -108,7 +125,6 @@ typedef unsigned __int128 DendroUInt_128;
 
 #define OCT_DIR_DOWN_BACK 14
 #define OCT_DIR_DOWN_FRONT 15
-
 
 #define OCT_DIR_UP_BACK 16
 #define OCT_DIR_UP_FRONT 17
@@ -125,9 +141,9 @@ typedef unsigned __int128 DendroUInt_128;
 
 #define OCT_DIR_TOTAL 27
 
-/** variable to ensure the element sz % element order =0 for higher order elemnts */
+/** variable to ensure the element sz % element order =0 for higher order
+ * elemnts */
 extern unsigned int MAXDEAPTH_LEVEL_DIFF;
-
 
 #define NUM_LEVEL_BITS 5u
 
@@ -162,7 +178,6 @@ extern unsigned int MAXDEAPTH_LEVEL_DIFF;
 #define F2E_FACE_INDEPEN_BIT 3
 #define F2E_FACE_DEPEN_BIT 4
 
-
 // AMR coarsening factor.
 #define DENDRO_AMR_COARSEN_FAC 0.1
 
@@ -170,16 +185,13 @@ extern unsigned int MAXDEAPTH_LEVEL_DIFF;
 #define DENDRO_DEFAULT_SF_K 2
 #define DENDRO_DEFAULT_GRAIN_SZ 100
 
-
 #define DENDRO_UNSIGNED_INT_MIN UINT_MIN
 #define DENDRO_UNSIGNED_INT_MAX UINT_MAX
 
 #define DENDRO_REMESH_UNZIP_SCALE_FAC 1.0
 
-
 #define DENDRO_BLOCK_ALIGN_FACTOR 1
 #define DENDRO_BLOCK_ALIGN_FACTOR_LOG 0
-
 
 #define ODA_INDEPENDENT_FLAG_BIT 0
 #define ODA_W_DEPENDENT_FLAG_BIT 1
@@ -189,9 +201,10 @@ extern unsigned int MAXDEAPTH_LEVEL_DIFF;
 
 void __handler(int sig);
 
-inline int dendro_error(const char* const file, int line, const std::string& msg){
-   std::cout<< "[" << file << "] : "<<line<<" "<< msg <<std::endl;
-   return 0;
+inline int dendro_error(const char* const file, int line,
+                        const std::string& msg) {
+    std::cout << "[" << file << "] : " << line << " " << msg << std::endl;
+    return 0;
 }
 
 #define dendro_log(msg) dendro_error(__FILE__, __LINE__, msg)

--- a/include/hcurvedata.h
+++ b/include/hcurvedata.h
@@ -28,8 +28,9 @@
 
 const int _2D_HILBERT_TABLE=16;
 const int _3D_HILBERT_TABLE=192;
-const int _2D_ROTATIONS_SIZE=32;
-const int _3D_ROTATIONS_SIZE=384;
+// rotations size needs to be +1 to avoid overwriting shadow blocks upon strcpy (fsanatize reveals this "bug")
+const int _2D_ROTATIONS_SIZE=32 + 1;
+const int _3D_ROTATIONS_SIZE=384 + 1;
 
 
 extern char* HILBERT_TABLE;

--- a/include/mesh.tcc
+++ b/include/mesh.tcc
@@ -643,93 +643,95 @@ namespace ot
     template<typename T>
     void Mesh::readFromGhostBegin(T* vec, unsigned int dof)
     {
-         if(this->getMPICommSizeGlobal()==1 || (!m_uiIsActive))
-            return;
+        if (this->getMPICommSizeGlobal() == 1 || (!m_uiIsActive)) return;
 
         // send recv buffers.
         T* sendB = NULL;
         T* recvB = NULL;
 
-        if(this->isActive())
-        {
-            const std::vector<unsigned int>& nodeSendCount=this->getNodalSendCounts();
-            const std::vector<unsigned int>& nodeSendOffset=this->getNodalSendOffsets();
+        if (this->isActive()) {
+            const std::vector<unsigned int>& nodeSendCount =
+                this->getNodalSendCounts();
+            const std::vector<unsigned int>& nodeSendOffset =
+                this->getNodalSendOffsets();
 
-            const std::vector<unsigned int>& nodeRecvCount=this->getNodalRecvCounts();
-            const std::vector<unsigned int>& nodeRecvOffset=this->getNodalRecvOffsets();
+            const std::vector<unsigned int>& nodeRecvCount =
+                this->getNodalRecvCounts();
+            const std::vector<unsigned int>& nodeRecvOffset =
+                this->getNodalRecvOffsets();
 
-            const std::vector<unsigned int>& sendProcList=this->getSendProcList();
-            const std::vector<unsigned int>& recvProcList=this->getRecvProcList();
+            const std::vector<unsigned int>& sendProcList =
+                this->getSendProcList();
+            const std::vector<unsigned int>& recvProcList =
+                this->getRecvProcList();
 
-            const std::vector<unsigned int>& sendNodeSM=this->getSendNodeSM();
-            const std::vector<unsigned int>& recvNodeSM=this->getRecvNodeSM();
+            const std::vector<unsigned int>& sendNodeSM = this->getSendNodeSM();
+            const std::vector<unsigned int>& recvNodeSM = this->getRecvNodeSM();
 
+            const unsigned int activeNpes = this->getMPICommSize();
 
-            const unsigned int activeNpes=this->getMPICommSize();
-
-            const unsigned int sendBSz=nodeSendOffset[activeNpes-1] + nodeSendCount[activeNpes-1];
-            const unsigned int recvBSz=nodeRecvOffset[activeNpes-1] + nodeRecvCount[activeNpes-1];
+            const unsigned int sendBSz =
+                nodeSendOffset[activeNpes - 1] + nodeSendCount[activeNpes - 1];
+            const unsigned int recvBSz =
+                nodeRecvOffset[activeNpes - 1] + nodeRecvCount[activeNpes - 1];
             unsigned int proc_id;
 
             AsyncExchangeContex ctx(vec);
-            MPI_Comm commActive=this->getMPICommunicator();
+            MPI_Comm commActive = this->getMPICommunicator();
 
-
-            if(recvBSz)
-            {
-                ctx.allocateRecvBuffer((sizeof(T)*recvBSz*dof));
-                recvB=(T*)ctx.getRecvBuffer();
+            if (recvBSz) {
+                ctx.allocateRecvBuffer((sizeof(T) * recvBSz * dof));
+                recvB = (T*)ctx.getRecvBuffer();
 
                 // active recv procs
-                for(unsigned int recv_p=0;recv_p<recvProcList.size();recv_p++)
-                {
-                    proc_id=recvProcList[recv_p];
-                    MPI_Request* req=new MPI_Request();
-                    par::Mpi_Irecv((recvB+dof*nodeRecvOffset[proc_id]),dof*nodeRecvCount[proc_id],proc_id,m_uiCommTag,commActive,req);
+                for (unsigned int recv_p = 0; recv_p < recvProcList.size();
+                     recv_p++) {
+                    proc_id = recvProcList[recv_p];
+                    MPI_Request* req = new MPI_Request();
+                    par::Mpi_Irecv((recvB + dof * nodeRecvOffset[proc_id]),
+                                   dof * nodeRecvCount[proc_id], proc_id,
+                                   m_uiCommTag, commActive, req);
                     ctx.getRequestList().push_back(req);
-
+                    std::cout << this->getMPIRank() << ": receiving from proc " << proc_id << " a total of " << dof * nodeRecvCount[proc_id] << std::endl;
                 }
-
             }
 
-            if(sendBSz)
-            {
-                ctx.allocateSendBuffer(sizeof(T)*dof*sendBSz);
-                sendB=(T*)ctx.getSendBuffer();
+            if (sendBSz) {
+                ctx.allocateSendBuffer(sizeof(T) * dof * sendBSz);
+                sendB = (T*)ctx.getSendBuffer();
 
-                for(unsigned int send_p=0;send_p<sendProcList.size();send_p++) {
-                    proc_id=sendProcList[send_p];
+                for (unsigned int send_p = 0; send_p < sendProcList.size();
+                     send_p++) {
+                    proc_id = sendProcList[send_p];
 
-                    for(unsigned int var=0;var<dof;var++)
-                    {
-                        for (unsigned int k = nodeSendOffset[proc_id]; k < (nodeSendOffset[proc_id] + nodeSendCount[proc_id]); k++)
-                        {
-                            sendB[dof*(nodeSendOffset[proc_id]) + (var*nodeSendCount[proc_id])+(k-nodeSendOffset[proc_id])] = (vec+var*m_uiNumActualNodes)[sendNodeSM[k]];
+                    for (unsigned int var = 0; var < dof; var++) {
+                        for (unsigned int k = nodeSendOffset[proc_id];
+                             k <
+                             (nodeSendOffset[proc_id] + nodeSendCount[proc_id]);
+                             k++) {
+                            sendB[dof * (nodeSendOffset[proc_id]) +
+                                  (var * nodeSendCount[proc_id]) +
+                                  (k - nodeSendOffset[proc_id])] =
+                                (vec + var * m_uiNumActualNodes)[sendNodeSM[k]];
                         }
-
                     }
-
-
-
                 }
 
                 // active send procs
-                for(unsigned int send_p=0;send_p<sendProcList.size();send_p++)
-                {
-                    proc_id=sendProcList[send_p];
-                    MPI_Request * req=new MPI_Request();
-                    par::Mpi_Isend(sendB+dof*nodeSendOffset[proc_id],dof*nodeSendCount[proc_id],proc_id,m_uiCommTag,commActive,req);
+                for (unsigned int send_p = 0; send_p < sendProcList.size();
+                     send_p++) {
+                    proc_id = sendProcList[send_p];
+                    MPI_Request* req = new MPI_Request();
+                    par::Mpi_Isend(sendB + dof * nodeSendOffset[proc_id],
+                                   dof * nodeSendCount[proc_id], proc_id,
+                                   m_uiCommTag, commActive, req);
                     ctx.getRequestList().push_back(req);
-
+                    std::cout << this->getMPIRank() << ": sending from proc " << proc_id << " a total of " << dof * nodeSendOffset[proc_id] << std::endl;
                 }
-
-
             }
 
             m_uiCommTag++;
             m_uiMPIContexts.push_back(ctx);
-
-
         }
 
         return;
@@ -738,91 +740,95 @@ namespace ot
     template<typename T>
     void Mesh::readFromGhostEnd(T* vec, unsigned int dof)
     {
-        if(this->getMPICommSizeGlobal()==1 || (!m_uiIsActive))
-            return;
+        if (this->getMPICommSizeGlobal() == 1 || (!m_uiIsActive)) return;
 
         // send recv buffers.
         T* sendB = NULL;
         T* recvB = NULL;
 
-        if(this->isActive())
-        {
-            const std::vector<unsigned int>& nodeSendCount=this->getNodalSendCounts();
-            const std::vector<unsigned int>& nodeSendOffset=this->getNodalSendOffsets();
+        if (this->isActive()) {
+            const std::vector<unsigned int>& nodeSendCount =
+                this->getNodalSendCounts();
+            const std::vector<unsigned int>& nodeSendOffset =
+                this->getNodalSendOffsets();
 
-            const std::vector<unsigned int>& nodeRecvCount=this->getNodalRecvCounts();
-            const std::vector<unsigned int>& nodeRecvOffset=this->getNodalRecvOffsets();
+            const std::vector<unsigned int>& nodeRecvCount =
+                this->getNodalRecvCounts();
+            const std::vector<unsigned int>& nodeRecvOffset =
+                this->getNodalRecvOffsets();
 
-            const std::vector<unsigned int>& sendProcList=this->getSendProcList();
-            const std::vector<unsigned int>& recvProcList=this->getRecvProcList();
+            const std::vector<unsigned int>& sendProcList =
+                this->getSendProcList();
+            const std::vector<unsigned int>& recvProcList =
+                this->getRecvProcList();
 
-            const std::vector<unsigned int>& sendNodeSM=this->getSendNodeSM();
-            const std::vector<unsigned int>& recvNodeSM=this->getRecvNodeSM();
+            const std::vector<unsigned int>& sendNodeSM = this->getSendNodeSM();
+            const std::vector<unsigned int>& recvNodeSM = this->getRecvNodeSM();
 
+            const unsigned int activeNpes = this->getMPICommSize();
 
-            const unsigned int activeNpes=this->getMPICommSize();
-
-            const unsigned int sendBSz=nodeSendOffset[activeNpes-1] + nodeSendCount[activeNpes-1];
-            const unsigned int recvBSz=nodeRecvOffset[activeNpes-1] + nodeRecvCount[activeNpes-1];
+            const unsigned int sendBSz =
+                nodeSendOffset[activeNpes - 1] + nodeSendCount[activeNpes - 1];
+            const unsigned int recvBSz =
+                nodeRecvOffset[activeNpes - 1] + nodeRecvCount[activeNpes - 1];
             unsigned int proc_id;
 
-            int ctxIndex=-1;
-            for(unsigned int i=0;i<m_uiMPIContexts.size();i++)
-            {
-                if(m_uiMPIContexts[i].getBuffer()==vec)
-                {
-                    ctxIndex=i;
+            int ctxIndex = -1;
+            for (unsigned int i = 0; i < m_uiMPIContexts.size(); i++) {
+                if (m_uiMPIContexts[i].getBuffer() == vec) {
+                    ctxIndex = i;
                     break;
                 }
-
             }
 
-            if(ctxIndex==-1)
-            {
-                std::cout<<"rank: "<<m_uiActiveRank<<" async ctx not found for vec: "<<&vec<<" in async comm end: "<<__LINE__<<std::endl;
-                MPI_Abort(m_uiCommActive,0);
+            if (ctxIndex == -1) {
+                std::cout << "rank: " << m_uiActiveRank
+                          << " async ctx not found for vec: " << &vec
+                          << " in async comm end: " << __LINE__ << std::endl;
+                MPI_Abort(m_uiCommActive, 0);
             }
 
             MPI_Status status;
             // need to wait for the commns to finish ...
-            for (unsigned int i = 0; i < m_uiMPIContexts[ctxIndex].getRequestList().size(); i++) {
-                MPI_Wait(m_uiMPIContexts[ctxIndex].getRequestList()[i], &status);
+            for (unsigned int i = 0;
+                 i < m_uiMPIContexts[ctxIndex].getRequestList().size(); i++) {
+                MPI_Wait(m_uiMPIContexts[ctxIndex].getRequestList()[i],
+                         &status);
             }
 
-            if(recvBSz)
-            {
+            if (recvBSz) {
                 // copy the recv data to the vec
-                recvB=(T*)m_uiMPIContexts[ctxIndex].getRecvBuffer();
+                recvB = (T*)m_uiMPIContexts[ctxIndex].getRecvBuffer();
 
-                for(unsigned int recv_p=0;recv_p<recvProcList.size();recv_p++){
-                    proc_id=recvProcList[recv_p];
+                for (unsigned int recv_p = 0; recv_p < recvProcList.size();
+                     recv_p++) {
+                    proc_id = recvProcList[recv_p];
 
-                    for(unsigned int var=0;var<dof;var++)
-                    {
-                        for (unsigned int k = nodeRecvOffset[proc_id]; k < (nodeRecvOffset[proc_id] + nodeRecvCount[proc_id]); k++)
-                        {
-                            (vec+var*m_uiNumActualNodes)[recvNodeSM[k]]=recvB[dof*(nodeRecvOffset[proc_id]) + (var*nodeRecvCount[proc_id])+(k-nodeRecvOffset[proc_id])];
+                    for (unsigned int var = 0; var < dof; var++) {
+                        for (unsigned int k = nodeRecvOffset[proc_id];
+                             k <
+                             (nodeRecvOffset[proc_id] + nodeRecvCount[proc_id]);
+                             k++) {
+                            (vec + var * m_uiNumActualNodes)[recvNodeSM[k]] =
+                                recvB[dof * (nodeRecvOffset[proc_id]) +
+                                      (var * nodeRecvCount[proc_id]) +
+                                      (k - nodeRecvOffset[proc_id])];
                         }
                     }
-
                 }
-
             }
-
-
 
             m_uiMPIContexts[ctxIndex].deAllocateSendBuffer();
             m_uiMPIContexts[ctxIndex].deAllocateRecvBuffer();
 
-            for (unsigned int i = 0; i < m_uiMPIContexts[ctxIndex].getRequestList().size(); i++)
+            for (unsigned int i = 0;
+                 i < m_uiMPIContexts[ctxIndex].getRequestList().size(); i++)
                 delete m_uiMPIContexts[ctxIndex].getRequestList()[i];
 
             m_uiMPIContexts[ctxIndex].getRequestList().clear();
 
             // remove the context ...
             m_uiMPIContexts.erase(m_uiMPIContexts.begin() + ctxIndex);
-
-
         }
 
         return;
@@ -7823,8 +7829,8 @@ namespace ot
         unsigned int faceNeighCnum2[4]={0,0,0,0}; // neighbor's neighbors
 
 
-        register unsigned int nodeLookUp_CG;
-        register unsigned int nodeLookUp_DG;
+        DendroRegister unsigned int nodeLookUp_CG;
+        DendroRegister unsigned int nodeLookUp_DG;
 
         std::vector<T> interpOrInjectionOut; // interpolation or injection output.
         std::vector<T> injectionInput;// input for the injection (values from all the 8 children) (This should be put in the order of the morton ordering. )

--- a/include/octUtils.h
+++ b/include/octUtils.h
@@ -282,8 +282,8 @@ void computeSFCBucketSplitters(const T *pNodes, int lev, unsigned int maxDepth,u
 
     }
 
-    register unsigned int cnum;
-    register unsigned int cnum_prev=0;
+    DendroRegister unsigned int cnum;
+    DendroRegister unsigned int cnum_prev=0;
     DendroIntL num_elements=0;
     unsigned int rotation=0;
     DendroIntL count[(NUM_CHILDREN+2)]={};

--- a/include/sfcSort.h
+++ b/include/sfcSort.h
@@ -430,9 +430,9 @@ namespace SFC {
         {
 
             if(n==0) return;
-            register unsigned int cnum;
-            register unsigned int cnum_prev=0;
-            //register unsigned int n=0;
+            DendroRegister unsigned int cnum;
+            DendroRegister unsigned int cnum_prev=0;
+            //DendroRegister unsigned int n=0;
             unsigned int rotation=0;
             DendroIntL count[(NUM_CHILDREN+2)]={};
             unsigned int lev=pMaxDepth-pMaxDepthBit;
@@ -689,8 +689,8 @@ namespace SFC {
 
             }
 
-            register unsigned int cnum;
-            register unsigned int cnum_prev=0;
+            DendroRegister unsigned int cnum;
+            DendroRegister unsigned int cnum_prev=0;
             DendroIntL num_elements=0;
             unsigned int rotation=0;
             DendroIntL count[(NUM_CHILDREN+2)]={};

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -569,11 +569,11 @@ namespace ot {
         ot::TreeNode *inPtr = (&(*(m_uiEmbeddedOctree.begin())));
         unsigned int domain_max = 1u<<(m_uiMaxDepth);
         SearchKey skey;
-        register unsigned int mySz;
-        register unsigned int myX;
-        register unsigned int myY;
-        register unsigned int myZ;
-        register unsigned int myLev;
+        DendroRegister unsigned int mySz;
+        DendroRegister unsigned int myX;
+        DendroRegister unsigned int myY;
+        DendroRegister unsigned int myZ;
+        DendroRegister unsigned int myLev;
         const unsigned int K=1;
 
 
@@ -698,11 +698,11 @@ namespace ot {
         ot::TreeNode *inPtr = (&(*(m_uiAllElements.begin())));
         unsigned int domain_max = 1u<<(m_uiMaxDepth);
         SearchKey skey;
-        register unsigned int mySz;
-        register unsigned int myX;
-        register unsigned int myY;
-        register unsigned int myZ;
-        register unsigned int myLev;
+        DendroRegister unsigned int mySz;
+        DendroRegister unsigned int myX;
+        DendroRegister unsigned int myY;
+        DendroRegister unsigned int myZ;
+        DendroRegister unsigned int myLev;
         const unsigned int K=1;
 
         for (unsigned int i = m_uiElementPreGhostBegin; i < m_uiElementPreGhostEnd; i++) {
@@ -912,11 +912,11 @@ namespace ot {
         unsigned int domain_max = 1u<<(m_uiMaxDepth);
         SearchKey skey;
         unsigned int elementLookUp;
-        register unsigned int mySz;
-        register unsigned int myX;
-        register unsigned int myY;
-        register unsigned int myZ;
-        register unsigned int myLev;
+        DendroRegister unsigned int mySz;
+        DendroRegister unsigned int myX;
+        DendroRegister unsigned int myY;
+        DendroRegister unsigned int myZ;
+        DendroRegister unsigned int myLev;
         const unsigned int K=1;
 
 


### PR DESCRIPTION
There are a few fixes here.

In C++ 17 and beyond, the register keyword is depreciated. Instead of just removing it, I added a definition for `DendroRegister` which will expand out to `register` if the C++ standard evoked is less than C++17 but will be removed otherwise.

As I was running some debug code to check for memory safety and access, the program noticed that there were shadow bytes with the Null terminator in the Hilbert rotations matrix. So I increased the size of the array by one to handle the null character.

Finally, there's a clangformat file that can be used for autoformatting for consistency.