### PR TITLE
Simple Bug Fixes for dvec.h and enuts.h

### DIFF
--- a/CMakeLists-NonLibraryDefs.txt
+++ b/CMakeLists-NonLibraryDefs.txt
@@ -70,6 +70,7 @@ option(WITH_CUDA " build dendro with cuda " OFF)
 option(BUILD_WITH_PETSC " build dendro with PETSC " OFF)
 option(USE_FD_INTERP_FOR_UNZIP "use FD style interpolation for unzip" OFF)
 option(MPIX_CUDA_AWARE_SUPPORT "use FD style interpolation for unzip" OFF)
+option(DVEC_ZERO_ALLOC "Make the memory allocation of dvec on CPU initialize as zeros" OFF)
 
 # option(KWAY "K parameter for alltoallv_kway" 128)
 set(KWAY
@@ -205,6 +206,10 @@ endif()
 
 if(USE_FD_INTERP_FOR_UNZIP)
   add_definitions(-DUSE_FD_INTERP_FOR_UNZIP)
+endif()
+
+if(DVEC_ZERO_ALLOC)
+  add_definitions(-DDVEC_ZERO_ALLOC)
 endif()
 
 add_definitions(-DMATVEC_PROFILE)

--- a/ODE/include/enuts.h
+++ b/ODE/include/enuts.h
@@ -766,6 +766,13 @@ namespace ts
         
         m_uiBVec.clear();
 
+        // deallocate m_uiStVec, which is based on the number of stages
+        for (unsigned int i = 0; i < m_uiNumStages; i++) {
+            m_uiStVec[i].destroy_vector();
+        }
+        m_uiStVec.clear(); 
+        
+
         m_uiBlkTimeLevMinMax.clear();
         
         m_uiActiveBlkIDs.clear();

--- a/include/dvec.h
+++ b/include/dvec.h
@@ -186,7 +186,7 @@ namespace ot
             #ifdef __CUDACC__
                 m_data_ptr = GPUDevice::host_malloc<T>(m_size);
             #else 
-                m_data_ptr = (T*) malloc(sizeof(T)*m_size);
+                m_data_ptr = (T*) calloc(m_size, sizeof(T));
             #endif
             
         }else if(m_vec_loc == DVEC_LOC::DEVICE)

--- a/include/dvec.h
+++ b/include/dvec.h
@@ -207,9 +207,6 @@ namespace ot
     template<typename T,typename I>
     void DVector<T,I>::set_vec_ptr(T*& ptr, const ot::Mesh* pMesh, DVEC_TYPE type, DVEC_LOC loc, unsigned int dof, bool allocate_ghost)
     {
-        if(!(pMesh->isActive()))
-            return;
-        
         m_dof       = dof;
         m_comm      = pMesh->getMPICommunicator();
         m_vec_type  = type;
@@ -230,6 +227,9 @@ namespace ot
             dendro_log(" unknown type in DVector");
             MPI_Abort(m_comm,0);
         }
+
+        if(!(pMesh->isActive()))
+            return;
 
         m_data_ptr = ptr;
         return;

--- a/include/dvec.h
+++ b/include/dvec.h
@@ -186,8 +186,15 @@ namespace ot
             #ifdef __CUDACC__
                 m_data_ptr = GPUDevice::host_malloc<T>(m_size);
             #else 
+
+            #ifdef DVEC_ZERO_ALLOC
                 m_data_ptr = (T*) calloc(m_size, sizeof(T));
+            #else
+                m_data_ptr = (T*) malloc(sizeof(T)*m_size);
             #endif
+            // end DVEC_ZERO_ALLOC
+            #endif
+            // end __CUDACC__ if
             
         }else if(m_vec_loc == DVEC_LOC::DEVICE)
         {   


### PR DESCRIPTION
Fixes a few bugs regarding memory leaks (see enuts.h, where one of the vectors wasn't being properly deleted).

Additionally, for a very small penalty, the program can now allocate memory that is initialized to all zeros (using calloc instead of malloc). This avoids nans in the padding regions beyond the physical region. This is especially useful for some mathematical methods that need to always *touch* beyond boundaries even if they are not used or overwritten. (Matrix multiplication on the blocks is the biggest reason for this addition.)

There was also an issue with dvec exiting too early on inactive meshes which lead to strange behavior when trying to run simulations.