### PR TITLE
Fix warnings and errors with ZLib compilation

### DIFF
--- a/IO/zlib/inc/gzguts.h
+++ b/IO/zlib/inc/gzguts.h
@@ -3,6 +3,8 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#include <unistd.h>
+
 #ifdef _LARGEFILE64_SOURCE
 #  ifndef _LARGEFILE_SOURCE
 #    define _LARGEFILE_SOURCE 1


### PR DESCRIPTION
Adds a single header to zlib's `gzguts.h` which removes errors about lseek. GCC's 14.1.1 made `-Wimplicit-function-declaration` warnings unable to be downgraded from errors. This header helps define the system we're building on so it can define the proper functions that zlib requires.